### PR TITLE
Fix PEFile module for Elasticsearch storage

### DIFF
--- a/modules/Metadata/PEFile.py
+++ b/modules/Metadata/PEFile.py
@@ -351,8 +351,8 @@ def _get_debug_info(pe):
     results = {}
     try:
         for dbg in pe.DIRECTORY_ENTRY_DEBUG:
-            dbg_path = ""
             if hasattr(dbg.struct, "Type"):
+                dbg_path = "debug"
                 result = {
                      'MajorVersion': dbg.struct.MajorVersion,
                      'MinorVersion': dbg.struct.MinorVersion,
@@ -401,8 +401,8 @@ def _get_debug_info(pe):
                                     'DebugPath': "%s" % dbg_path,
                                     'result': "%s" % dbg_path,
                                 })
-            #self._add_result('pe_debug', dbg_path, result)
-            results[dbg_path] = result
+                #self._add_result('pe_debug', dbg_path, result)
+                results[dbg_path] = result
     except Exception as e:
         #self._parse_error("could not extract debug info", e)
         print(e)


### PR DESCRIPTION
This PR provides a default dbg_path so that the result won't contain any empty strings as keys in debug_info. Also moves some code inside an if statement, since execution might not go inside the if statement and result wouldn't be set to anything.

Fix #27.