### PR TITLE
Add new pehash module.

### DIFF
--- a/modules/Metadata/pehasher.py
+++ b/modules/Metadata/pehasher.py
@@ -1,0 +1,76 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
+try:
+    import pefile
+except:
+    print("pefile module not installed...")
+    pefile = False
+
+try:
+    import pehash
+    HASH_FUNCS = {
+        'totalhash': pehash.totalhash,
+        'anymaster': pehash.anymaster,
+        'anymaster_v1_0_1': pehash.anymaster_v1_0_1,
+        'endgame': pehash.endgame,
+        'crits': pehash.crits,
+        'pehashng': pehash.pehashng,
+    }
+except:
+    print("pehash module not installed...")
+    pehash = False
+
+from common import hashfile
+import hashlib
+import time
+import sys
+
+PY3 = False
+if sys.version_info > (3,):
+    PY3 = True
+
+__author__ = "Patrick Copeland"
+__credits__ = ["knowmalware"]
+__license__ = "MPL 2.0"
+
+TYPE = "Metadata"
+NAME = "pehash"
+REQUIRES = ["libmagic"]
+DEFAULTCONF = {
+    'ENABLED': True,
+}
+
+def check(conf=DEFAULTCONF):
+    if not conf['ENABLED'] or \
+       not pefile or \
+       not pehash or \
+       None in REQUIRES:
+        return False
+    return True
+
+def scan(filelist, conf=DEFAULTCONF):
+    results = []
+    libmagicresults, libmagicmeta = REQUIRES[0]
+
+    for fname, libmagicresult in libmagicresults:
+        if fname not in filelist:
+            print("DEBUG: File not in filelist")
+        if not libmagicresult.startswith('PE32'):
+            continue
+        pe_hashes = {}
+        pe = pefile.PE(fname)
+        for name, hasher in HASH_FUNCS.items():
+            try:
+                pe_hashes[name] = hasher(pe=pe, raise_on_error=True).hexdigest()
+            except Exception as e:
+                print('pehash ({}):'.format(name), e)
+        results.append((fname, pe_hashes))
+
+    metadata = {}
+    metadata["Name"] = NAME
+    metadata["Type"] = TYPE
+    metadata["Include"] = False
+    return (results, metadata)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ future
 configparser
 #Required by modules
 bitstring
+git+https://github.com/knowmalware/pehash.git#egg=pehash
 paramiko
 pefile
 pyclamd


### PR DESCRIPTION
Uses the known implementations of pehash alg from https://github.com/knowmalware/pehash.

Ref about current state of pehash alg: https://gist.github.com/wxsBSD/07a5709fdcb59d346e9e

[This PR](https://github.com/knowmalware/pehash/pull/3) has some fixes for known issues with Python 3 compatibility. 

Sample output:
```
{
    "/tmp/7z465.exe": {
        "libmagic": "PE32 executable (GUI) Intel 80386, for MS Windows, Nullsoft Installer self-extracting archive",
        "MD5": "fcd1b1472302fc7283147f4df471f402",
        "pehash": {
            "totalhash": "4a78d5d83ea85c534be7bffc00e6637616e44bf9",
            "anymaster": "662e3a3c1e5430c51d25e7adfb18b22b3c4cd161",
            "anymaster_v1_0_1": "085a8a3454183adadc20cbe2f034b98fa2a4d775",
            "endgame": "dd00a9c21914d71758a3e22dc3430631",
            "crits": "60046843c85b94f87bdc9be5f9ecae7983f83d43",
            "pehashng": "3381c8855941fa1a9ac91d84da71a21a743e031af3fde9cc0db202717109202e"
        },
        "SHA1": "c36012e960fa3932cd23f30ac5b0fe722740243a",
        "SHA256": "8fe800a740fbe1beb1cfbd9ef73e413f5c18d1496741839399c1cefcaee3b211",
        "ssdeep": "24576:AwAFRpH+pkvLIbkCnGyIwLhCHbYsZyV6i/xu:7A9+pscbnGy5LebhMw"
    }
}
```