### PR TITLE
[MRG] Use basename first than split

### DIFF
--- a/multiscanner.py
+++ b/multiscanner.py
@@ -397,10 +397,10 @@ def _write_missing_module_configs(ModuleList, Config, filepath=CONFIG):
     ModuleList.sort()
     for module in ModuleList:
         if module.endswith(".py"):
-            modname = os.path.basename(module.split('.')[0])
+            modname = os.path.basename(module).split('.')[0]
             moddir = os.path.dirname(module)
             if modname not in Config.sections():
-                mod = load_module(os.path.basename(module.split('.')[0]), [moddir])
+                mod = load_module(os.path.basename(module).split('.')[0], [moddir])
                 if mod:
                     try:
                         conf = mod.DEFAULTCONF
@@ -437,9 +437,9 @@ def _rewrite_config(ModuleList, Config, filepath=CONFIG):
     ModuleList.sort()
     for module in ModuleList:
         if module.endswith(".py"):
-            modname = os.path.basename(module.split('.')[0])
+            modname = os.path.basename(module).split('.')[0]
             moddir = os.path.dirname(module)
-            mod = load_module(os.path.basename(module.split('.')[0]), [moddir])
+            mod = load_module(os.path.basename(module).split('.')[0], [moddir])
             if mod:
                 try:
                     conf = mod.DEFAULTCONF

--- a/multiscanner.py
+++ b/multiscanner.py
@@ -352,7 +352,7 @@ def _start_module_threads(filelist, ModuleList, config, global_module_interface)
         if module.endswith(".py"):
             modname = os.path.basename(module[:-3])
             moddir = os.path.dirname(module)
-            mod = load_module(os.path.basename(module.split('.')[0]), [moddir])
+            mod = load_module(os.path.basename(module).split('.')[0], [moddir])
             if not mod:
                 print(module, " not a valid module...")
                 continue


### PR DESCRIPTION
Fix issue #60

/Users/username/virtualenv/env3/lib/python3`.`6/site-packages/multiscanner/modules/Antivirus/ClamAVScan`.`py

`os.path.basename` must be executed earlier than `module.split('.')` 
Because of python module path, It contains `.` at library path already