### PR TITLE
Fix tika module

### DIFF
--- a/modules/Metadata/Tika.py
+++ b/modules/Metadata/Tika.py
@@ -32,7 +32,7 @@ def scan(filelist, conf=DEFAULTCONF):
     results = []
 
     for f in filelist:
-        metadata = parser.from_file(f)['metadata']
+        metadata = parser.from_file(f).get('metadata', {})
         for field in conf['remove-entry']:
             if field in metadata:
                 del metadata[field]


### PR DESCRIPTION
Tika server throws 422 errors on some documents. This is designed to catch those errors and still behave normally