### PR TITLE
[Web UI] Replace Status with Timestamp on Analyses page

### DIFF
--- a/web/templates/analyses.html
+++ b/web/templates/analyses.html
@@ -33,10 +33,14 @@
       },
       columnDefs: [
         {
+          targets: 2,
+          data: 3,
+        },
+        {
           targets: 3,
           searchable: false,
           orderable: false,
-          data: 0,
+          data: null,
           className: "text-center delete",
           "render": function ( data, type, full, meta ) {
             // Add Delete column buttons
@@ -188,8 +192,8 @@
       <thead>
         <tr>
           <th width="5%">Task ID</th>
-          <th width="75%">Sample</th>
-          <th width="14%">Task Status</th>
+          <th width="72%">Sample</th>
+          <th width="17%">Timestamp</th>
           <th class="text-center" width="6%">Delete</th>
         </tr>
       </thead>

--- a/web/templates/history.html
+++ b/web/templates/history.html
@@ -36,7 +36,7 @@
           targets: 4,
           searchable: false,
           orderable: false,
-          data: 0,
+          data: null,
           className: "text-center delete",
           "render": function ( data, type, full, meta ) {
             // Add Delete column buttons


### PR DESCRIPTION
On Analyses page, all tasks will be "Complete" so it doesn't make sense to include Task Status as one of the columns.