### PR TITLE
Add STIX2 output capability to multiscanner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,10 @@ pefile
 pyclamd
 python-magic
 requests
-ssdeep
 tika
 yara-python
+#Required for STIX2 content
+stix2
 #Required for PDF
 reportlab
 #Required by API

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pefile
 pyclamd
 python-magic
 requests
+ssdeep
 tika
 yara-python
 #Required for STIX2 content

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'pyclamd',
         'python-magic',
         'requests',
+        'ssdeep',
         # Required for STIX2 content
         'stix2',
         # Required by PDF

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
         'pyclamd',
         'python-magic',
         'requests',
-        'ssdeep',
+        # Required for STIX2 content
+        'stix2',
         # Required by PDF
         'reportlab',
         # Required by API

--- a/tests/utils/stix2_generator/sample_report.json
+++ b/tests/utils/stix2_generator/sample_report.json
@@ -1,0 +1,189 @@
+{
+  "Report": {
+    "Cuckoo Sandbox": {
+      "dropped": [
+        {
+          "crc32": "EDB36492",
+          "filepath": "C:\\Users\\some_user\\AppData\\Local\\Temp\\n2422\\s2429.exe.zip",
+          "md5": "d659e8900ea3fabe425882debed0c494",
+          "name": "1acf42374fb021fd_s2429.exe.zip",
+          "path": "/opt/cuckoo/.cuckoo/storage/analyses/22605/files/1acf42374fb021fd_s2429.exe.zip",
+          "pids": [
+            2272
+          ],
+          "sha1": "388e6816aff442e13cb546cfacd0c1d75b59b5b1",
+          "sha256": "1acf42374fb021fd1172df27a06f72e0e59f69a0bfaaaaea56f28dff6af01110",
+          "sha512": "f7e2de13afe330c96be43320968fc1152ef30562cd5e51a2b60306caffdea50745b1d515112cd09b0aaf1ba33c64bdd835d9999ec01f09aae8dbe01407d98e82",
+          "size": 173228,
+          "ssdeep": "3072:v8O0PPXlpAmOvDtu31DunkJdmAOIAT3B/WAyU98SJ4MWFYAkOymiTG4czJE:kdPP1Cm+OKYdmoqH8SSpkOye4czO",
+          "type": "Zip archive data, at least v2.0 to extract"
+        },
+        {
+          "crc32": "D29343CF",
+          "filepath": "C:\\Users\\some_user\\AppData\\Local\\Temp\\n2422\\s2429.exe",
+          "md5": "13b0085a03720e67fb8c73db3f14609e",
+          "name": "f9449897f9ca99b9_s2429.exe",
+          "path": "/opt/cuckoo/.cuckoo/storage/analyses/22605/files/f9449897f9ca99b9_s2429.exe",
+          "pids": [
+            2272
+          ],
+          "sha1": "ddf811f21e6c066b644d03e6751e16efb0fbecce",
+          "sha256": "f9449897f9ca99b99837ad322c8b6737e7a47e3827b6a4c073c6ca8911d8c340",
+          "sha512": "39b95dce14b3eea6f191d4dbaaff87ebbc8f3b6982e7b4ee5ebeed83d3b7397441665f25dec5eb9f8a1f3b12f4ddcd604d5852b781f592488263161c0d620e82",
+          "size": 421056,
+          "ssdeep": "6144:63hJxWjDKn4yTxz12wj/CF6J2Os+WX+ugnZJFNpluJHA4:6RJWDsTxzIwj/CF6FR6+zcO4",
+          "type": "PE32 executable (GUI) Intel 80386 Mono/.Net assembly, for MS Windows"
+        }
+      ],
+      "signatures": [
+        {
+          "description": "This executable is signed",
+          "name": "has_authenticode",
+          "severity": 1
+        },
+        {
+          "description": "Checks amount of memory in system, this can be used to detect virtual machines that have a low amount of memory available",
+          "markcount": 1,
+          "marks": [
+            {
+              "call": {
+                "api": "GlobalMemoryStatusEx",
+                "category": "system",
+                "return_value": 1,
+                "status": 1,
+                "tid": 1156,
+                "time": 1508411224.064626
+              },
+              "cid": 4115,
+              "pid": 2272,
+              "type": "call"
+            }
+          ],
+          "name": "antivm_memory_available",
+          "severity": 1
+        },
+        {
+          "description": "Potentially malicious URLs were found in the process memory dump",
+          "markcount": 3,
+          "marks": [
+            {
+              "category": "url",
+              "description": null,
+              "ioc": "http://ns.adobe.com/xap/1.0/mm/",
+              "type": "ioc"
+            },
+            {
+              "category": "url",
+              "description": null,
+              "ioc": "http://ns.adobe.com/xap/1.0/sType/ResourceRef",
+              "type": "ioc"
+            },
+            {
+              "category": "url",
+              "description": null,
+              "ioc": "http://ns.adobe.com/xap/1.0/",
+              "type": "ioc"
+            }
+          ],
+          "name": "memdump_urls",
+          "severity": 2
+        },
+        {
+          "description": "Performs some HTTP requests",
+          "markcount": 14,
+          "marks": [
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "GET http://www.msftncsi.com/ncsi.txt",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "GET http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?ec38990cc55170ab",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "POST http://tools.google.com/service/update2?cup2key=6:2144477707&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "POST http://tools.google.com/service/update2?cup2key=6:3255292227&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "POST http://tools.google.com/service/update2?cup2key=6:1128284371&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "POST http://tools.google.com/service/update2?cup2key=6:1439439368&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "GET http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/disallowedcertstl.cab?075dc50dacf9f2bb",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "GET http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?31308c2120fea4bc",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "GET http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?6ecb1b8de9d8006f",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "GET http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?91c8a9092e8cb67a",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "GET http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?1390637153eb96bd",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "GET http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?b16bed41061b4861",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "GET http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?9a8ede518893069d",
+              "type": "ioc"
+            },
+            {
+              "category": "request",
+              "description": null,
+              "ioc": "GET http://go.microsoft.com/fwlink/?LinkId=544713",
+              "type": "ioc"
+            }
+          ],
+          "name": "network_http",
+          "severity": 2
+        }
+      ]
+    },
+    "MD5": "34303fdb55e5d0f1142bb07eed2064cb",
+    "SHA1": "91fd2d2935aedcb47271b54cd22f8fe3b30c17fd",
+    "SHA256": "90b1e39282dbda2341d91b87ca161afe564b7d3b4f82f25b3f1dce3fa857226c"
+  }
+}

--- a/tests/utils/stix2_generator/test_stix2_generator.py
+++ b/tests/utils/stix2_generator/test_stix2_generator.py
@@ -1,32 +1,188 @@
+import json
+import os
+import sys
+
+import stix2
+
+
+CWD = os.path.dirname(os.path.abspath(__file__))
+MS_WD = os.path.dirname(os.path.dirname(os.path.abspath(__file__))).rstrip('\\tests\\utils')
+
+sys.path.insert(0, os.path.dirname(CWD))
+
+# Allow import of stix2_generator
+if os.path.join(MS_WD, 'utils\\stix2_generator') not in sys.path:
+    sys.path.insert(0, os.path.join(MS_WD, 'utils'))
+    sys.path.insert(0, os.path.join(MS_WD, 'utils\\stix2_generator'))
+
+
+import stix2_generator
 
 
 def test_create_empty_bundle():
-    pass
+    bundle = stix2_generator.create_stix2_bundle([])
+    assert isinstance(bundle, stix2.Bundle)
 
 
 def test_create_non_empty_bundle():
-    pass
+    indicator1 = stix2.Indicator(**{
+        'labels': ['benign'],
+        'pattern': '[ ipv4-addr:value = \'198.51.100.1/32\' ]'
+    })
+    indicator2 = stix2.Indicator(**{
+        'labels': ['benign'],
+        'pattern': '[ ipv4-addr:value = \'203.0.113.33/32\' ]'
+    })
+    bundle = stix2_generator.create_stix2_bundle([indicator1, indicator2])
+
+    assert isinstance(bundle, stix2.Bundle)
+    assert bundle.type == 'bundle'
+    assert bundle.id.startswith('bundle--')
+    assert bundle.spec_version == '2.0'
+    assert all(x in bundle.objects for x in (indicator1, indicator2))
 
 
 def test_join_comparison_expression():
-    pass
+    exp = stix2_generator.join_stix2_comparison_expression(
+        ['ipv4-addr:value = \'198.51.100.1/32\'',
+         'ipv4-addr:value = \'203.0.113.33/32\''], 'OR')
+
+    assert exp == ('ipv4-addr:value = \'198.51.100.1/32\' OR '
+                   'ipv4-addr:value = \'203.0.113.33/32\'')
 
 
 def test_create_comparison_expression():
-    pass
+    exp = stix2_generator.create_stix2_comparison_expression(
+        'ipv4-addr:value',
+        '=',
+        '198.51.100.1/32'
+    )
+
+    assert exp == 'ipv4-addr:value = \'198.51.100.1/32\''
 
 
 def test_create_observation_expression():
-    pass
+    comparison_exp = stix2_generator.create_stix2_comparison_expression(
+        'ipv4-addr:value',
+        '=',
+        '198.51.100.1/32'
+    )
+
+    observation_exp = stix2_generator.create_sti2_observation_expression(
+        comparison_exp
+    )
+
+    assert observation_exp == '[ ipv4-addr:value = \'198.51.100.1/32\' ]'
+
+
+def test_create_observation_expression_list():
+    comparison_exp_1 = stix2_generator.create_stix2_comparison_expression(
+        'ipv4-addr:value',
+        '=',
+        '198.51.100.1/32'
+    )
+
+    comparison_exp_2 = stix2_generator.create_stix2_comparison_expression(
+        'ipv4-addr:value',
+        '=',
+        '203.0.113.33/32'
+    )
+
+    all_comparison_exp = [comparison_exp_1, comparison_exp_2]
+
+    observation_exp = stix2_generator.create_sti2_observation_expression(
+        all_comparison_exp, 'OR'
+    )
+
+    assert observation_exp == ('[ ipv4-addr:value = \'198.51.100.1/32\' OR '
+                               'ipv4-addr:value = \'203.0.113.33/32\' ]')
 
 
 def test_extract_file_cuckoo():
-    pass
+    all_indicators_expressions = [
+        '[ file:name = \'s2429.exe.zip\' OR file:hashes.\'SHA-1\' = \'388e6816aff442e13cb546cfacd0c1d75b59b5b1\' OR file:hashes.\'SHA-256\' = \'1acf42374fb021fd1172df27a06f72e0e59f69a0bfaaaaea56f28dff6af01110\' OR file:hashes.\'MD5\' = \'d659e8900ea3fabe425882debed0c494\' ]',
+        '[ file:name = \'s2429.exe\' OR file:hashes.\'SHA-1\' = \'ddf811f21e6c066b644d03e6751e16efb0fbecce\' OR file:hashes.\'SHA-256\' = \'f9449897f9ca99b99837ad322c8b6737e7a47e3827b6a4c073c6ca8911d8c340\' OR file:hashes.\'MD5\' = \'13b0085a03720e67fb8c73db3f14609e\' ]'
+    ]
+    extracted_indicator_expressions = []
+
+    with open('sample_report.json') as sample_report:
+        sample_json = json.load(sample_report)
+        r = sample_json.get('Report', {})
+        cuckoo = r.get('Cuckoo Sandbox', {})
+
+        for d in cuckoo.get('dropped', []):
+            extracted_indicator_expressions.append(
+                stix2_generator.extract_file_cuckoo(d).pattern
+            )
+
+    assert all(x in all_indicators_expressions for x in extracted_indicator_expressions)
 
 
 def test_extract_http_requests_cuckoo():
-    pass
+    all_indicators_expressions = [
+        '[ url:value = \'http://www.msftncsi.com/ncsi.txt\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?ec38990cc55170ab\' ]',
+        '[ url:value = \'http://tools.google.com/service/update2?cup2key=6:2144477707&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc\' ]',
+        '[ url:value = \'http://tools.google.com/service/update2?cup2key=6:3255292227&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc\' ]',
+        '[ url:value = \'http://tools.google.com/service/update2?cup2key=6:1128284371&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc\' ]',
+        '[ url:value = \'http://tools.google.com/service/update2?cup2key=6:1439439368&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/disallowedcertstl.cab?075dc50dacf9f2bb\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?31308c2120fea4bc\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?6ecb1b8de9d8006f\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?91c8a9092e8cb67a\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?1390637153eb96bd\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?b16bed41061b4861\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?9a8ede518893069d\' ]',
+        '[ url:value = \'http://go.microsoft.com/fwlink/?LinkId=544713\' ]'
+    ]
+    extracted_indicator_expressions = []
+
+    with open('sample_report.json') as sample_report:
+        sample_json = json.load(sample_report)
+        r = sample_json.get('Report', {})
+        cuckoo = r.get('Cuckoo Sandbox', {})
+
+        for s in cuckoo.get('signatures', []):
+            if 'description' in s and 'HTTP request' in s.get('description', ''):
+                extracted_indicator_expressions.extend([
+                    x.pattern
+                    for x in stix2_generator.extract_http_requests_cuckoo(s)
+                ])
+
+    assert all(x in all_indicators_expressions for x in extracted_indicator_expressions)
 
 
 def test_parse_json_report_to_stix2_bundle():
-    pass
+    all_indicators_expressions = [
+        '[ file:name = \'s2429.exe.zip\' OR file:hashes.\'SHA-1\' = \'388e6816aff442e13cb546cfacd0c1d75b59b5b1\' OR file:hashes.\'SHA-256\' = \'1acf42374fb021fd1172df27a06f72e0e59f69a0bfaaaaea56f28dff6af01110\' OR file:hashes.\'MD5\' = \'d659e8900ea3fabe425882debed0c494\' ]',
+        '[ file:name = \'s2429.exe\' OR file:hashes.\'SHA-1\' = \'ddf811f21e6c066b644d03e6751e16efb0fbecce\' OR file:hashes.\'SHA-256\' = \'f9449897f9ca99b99837ad322c8b6737e7a47e3827b6a4c073c6ca8911d8c340\' OR file:hashes.\'MD5\' = \'13b0085a03720e67fb8c73db3f14609e\' ]',
+        '[ url:value = \'http://www.msftncsi.com/ncsi.txt\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?ec38990cc55170ab\' ]',
+        '[ url:value = \'http://tools.google.com/service/update2?cup2key=6:2144477707&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc\' ]',
+        '[ url:value = \'http://tools.google.com/service/update2?cup2key=6:3255292227&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc\' ]',
+        '[ url:value = \'http://tools.google.com/service/update2?cup2key=6:1128284371&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc\' ]',
+        '[ url:value = \'http://tools.google.com/service/update2?cup2key=6:1439439368&cup2hreq=a6c83ff1daef97153eb6f265f9181edc5cea9a80f527aea825c28f6307c1fdfc\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/disallowedcertstl.cab?075dc50dacf9f2bb\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?31308c2120fea4bc\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?6ecb1b8de9d8006f\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?91c8a9092e8cb67a\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?1390637153eb96bd\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?b16bed41061b4861\' ]',
+        '[ url:value = \'http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/authrootstl.cab?9a8ede518893069d\' ]',
+        '[ url:value = \'http://go.microsoft.com/fwlink/?LinkId=544713\' ]',
+        '[ url:value = \'http://ns.adobe.com/xap/1.0/mm/\' ]',
+        '[ url:value = \'http://ns.adobe.com/xap/1.0/sType/ResourceRef\' ]',
+        '[ url:value = \'http://ns.adobe.com/xap/1.0/\' ]',
+        '[ file:hashes.\'SHA-1\' = \'91fd2d2935aedcb47271b54cd22f8fe3b30c17fd\' OR file:hashes.\'SHA-256\' = \'90b1e39282dbda2341d91b87ca161afe564b7d3b4f82f25b3f1dce3fa857226c\' OR file:hashes.\'MD5\' = \'34303fdb55e5d0f1142bb07eed2064cb\' ]'
+    ]
+    extracted_indicator_expressions = []
+
+    with open('sample_report.json') as sample_report:
+        sample_json = json.load(sample_report)
+        bundle = stix2_generator.parse_json_report_to_stix2_bundle(sample_json)
+
+        for x in bundle.objects:
+            if isinstance(x, stix2.Indicator):
+                extracted_indicator_expressions.append(x.pattern)
+
+    assert all(x in all_indicators_expressions for x in extracted_indicator_expressions)

--- a/tests/utils/stix2_generator/test_stix2_generator.py
+++ b/tests/utils/stix2_generator/test_stix2_generator.py
@@ -70,7 +70,7 @@ def test_create_observation_expression():
         '198.51.100.1/32'
     )
 
-    observation_exp = stix2_generator.create_sti2_observation_expression(
+    observation_exp = stix2_generator.create_stix2_observation_expression(
         comparison_exp
     )
 
@@ -92,7 +92,7 @@ def test_create_observation_expression_list():
 
     all_comparison_exp = [comparison_exp_1, comparison_exp_2]
 
-    observation_exp = stix2_generator.create_sti2_observation_expression(
+    observation_exp = stix2_generator.create_stix2_observation_expression(
         all_comparison_exp, 'OR'
     )
 

--- a/tests/utils/stix2_generator/test_stix2_generator.py
+++ b/tests/utils/stix2_generator/test_stix2_generator.py
@@ -4,17 +4,19 @@ import sys
 
 import stix2
 
+'''Test module for STIX2 content generation methods'''
 
 CWD = os.path.dirname(os.path.abspath(__file__))
-MS_WD = os.path.dirname(os.path.dirname(os.path.abspath(__file__))).rstrip('\\tests\\utils')
+MODULE_TEST_DIR = os.path.dirname(CWD)
+TEST_DIR = os.path.dirname(MODULE_TEST_DIR)
+MS_WD = os.path.dirname(TEST_DIR)
 
-sys.path.insert(0, os.path.dirname(CWD))
 
 # Allow import of stix2_generator
-if os.path.join(MS_WD, 'utils\\stix2_generator') not in sys.path:
+if os.path.join(MS_WD, 'utils') not in sys.path:
     sys.path.insert(0, os.path.join(MS_WD, 'utils'))
-    sys.path.insert(0, os.path.join(MS_WD, 'utils\\stix2_generator'))
-
+# Use multiscanner in ../
+sys.path.insert(0, os.path.dirname(CWD))
 
 import stix2_generator
 
@@ -105,7 +107,7 @@ def test_extract_file_cuckoo():
     ]
     extracted_indicator_expressions = []
 
-    with open('sample_report.json') as sample_report:
+    with open(os.path.join(CWD, 'sample_report.json')) as sample_report:
         sample_json = json.load(sample_report)
         r = sample_json.get('Report', {})
         cuckoo = r.get('Cuckoo Sandbox', {})
@@ -137,7 +139,7 @@ def test_extract_http_requests_cuckoo():
     ]
     extracted_indicator_expressions = []
 
-    with open('sample_report.json') as sample_report:
+    with open(os.path.join(CWD, 'sample_report.json')) as sample_report:
         sample_json = json.load(sample_report)
         r = sample_json.get('Report', {})
         cuckoo = r.get('Cuckoo Sandbox', {})
@@ -177,7 +179,7 @@ def test_parse_json_report_to_stix2_bundle():
     ]
     extracted_indicator_expressions = []
 
-    with open('sample_report.json') as sample_report:
+    with open(os.path.join(CWD, 'sample_report.json')) as sample_report:
         sample_json = json.load(sample_report)
         bundle = stix2_generator.parse_json_report_to_stix2_bundle(sample_json)
 

--- a/tests/utils/stix2_generator/test_stix2_generator.py
+++ b/tests/utils/stix2_generator/test_stix2_generator.py
@@ -1,0 +1,32 @@
+
+
+def test_create_empty_bundle():
+    pass
+
+
+def test_create_non_empty_bundle():
+    pass
+
+
+def test_join_comparison_expression():
+    pass
+
+
+def test_create_comparison_expression():
+    pass
+
+
+def test_create_observation_expression():
+    pass
+
+
+def test_extract_file_cuckoo():
+    pass
+
+
+def test_extract_http_requests_cuckoo():
+    pass
+
+
+def test_parse_json_report_to_stix2_bundle():
+    pass

--- a/utils/api.py
+++ b/utils/api.py
@@ -904,6 +904,8 @@ def get_pdf_report(task_id):
 def get_stix2_bundle_from_report(task_id):
     '''
     Generates a STIX2 Bundle with indicators generated of a JSON report.
+
+    custom labels must be comma-separated.
     '''
     report_dict, success = get_report_dict(task_id)
 

--- a/utils/api.py
+++ b/utils/api.py
@@ -25,7 +25,7 @@ PUT /api/v1/tasks/<task_id>/notes/<note_id> ---> Edit a note
 DELETE /api/v1/tasks/<task_id>/notes/<note_id> ---> Delete a note
 GET /api/v1/tasks/<task_id>/report?d={t|f}---> receive report in JSON, set d=t to download
 GET /api/v1/tasks/<task_id>/pdf ---> Receive PDF report
-GET /api/v1/tasks/<task_id>/stix2?pretty={t|f} ---> Receive STIX2 Bundle from report
+GET /api/v1/tasks/<task_id>/stix2?pretty={t|f}&custom_labels={string} ---> Receive STIX2 Bundle from report
 POST /api/v1/tasks/<task_id>/tags ---> Add tags to task
 DELETE /api/v1/tasks/<task_id>/tags ---> Remove tags from task
 GET /api/v1/analytics/ssdeep_compare---> Run ssdeep.compare analytic
@@ -911,16 +911,21 @@ def get_stix2_bundle_from_report(task_id):
         return jsonify(report_dict)
 
     formatting = request.args.get('pretty', default='False', type=str)[0].lower()
+    custom_labels = request.args.get('custom_labels', default='', type=str).split(",")
 
     if formatting == 't' or formatting == 'y' or formatting == '1':
         formatting = True
     else:
         formatting = False
 
+    # If list is empty or any entry in the list is empty -> clear labels
+    if custom_labels or all(custom_labels) is False:
+        custom_labels = []
+
     # If the report has no key/value pairs that we can use to create
     # STIX representations of this data. The default behavior is to return
     # an empty bundle.
-    bundle = parse_json_report_to_stix2_bundle(report_dict)
+    bundle = parse_json_report_to_stix2_bundle(report_dict, custom_labels)
 
     # Setting pretty=True can be an expensive operation!
     response = make_response(bundle.serialize(pretty=formatting))

--- a/utils/api.py
+++ b/utils/api.py
@@ -905,17 +905,17 @@ def get_stix2_bundle_from_report(task_id):
     '''
     Generates a STIX2 Bundle with indicators generated of a JSON report.
     '''
-    formatting = request.args.get('pretty', default='False', type=str)[0].lower()
-
     report_dict, success = get_report_dict(task_id)
+
+    if not success:
+        return jsonify(report_dict)
+
+    formatting = request.args.get('pretty', default='False', type=str)[0].lower()
 
     if formatting == 't' or formatting == 'y' or formatting == '1':
         formatting = True
     else:
         formatting = False
-
-    if not success:
-        return jsonify(report_dict)
 
     # If the report has no key/value pairs that we can use to create
     # STIX representations of this data. The default behavior is to return

--- a/utils/stix2_generator/__init__.py
+++ b/utils/stix2_generator/__init__.py
@@ -1,0 +1,253 @@
+from __future__ import (division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+import stix2
+
+
+def create_stix2_bundle(objects):
+    '''
+    Creates a STIX2 Bundle object from a list of objects.
+
+    Args:
+        objects: list of ``stix2`` SDO objects.
+
+    Returns:
+        A ``stix2.Bundle`` instance.
+
+    '''
+    return stix2.Bundle(objects=objects)
+
+
+def join_stix2_comparison_expression(comp_exps, obs_operator):
+    '''
+    Joins multiple comparison expressions using the same observable operator.
+
+    Args:
+        comp_exps: A list of comparison expressions
+        obs_operator: A observation operator (e.g., 'OR' or 'AND')
+
+    Returns:
+        str: Containing the full observation expression joined by the specified
+            operator.
+
+    Example:
+        >>> join_stix2_comparison_expression(
+        ...     ['ipv4-addr:value = \\'198.51.100.1/32\\'',
+        ...     'ipv4-addr:value = \\'203.0.113.33/32\\''], 'OR')
+        'ipv4-addr:value = \'198.51.100.1/32\' OR ipv4-addr:value = \'203.0.113.33/32\''
+
+    '''
+    return " {observation_operator} ".format(observation_operator=
+                                             obs_operator).join(comp_exps)
+
+
+def create_stix2_comparison_expression(lhs, op, rhs):
+    '''
+    Creates a comparison expression.
+
+    Args:
+        lhs: A string containing the left-hand side of the expression
+        op: A string containing the operator to use.
+        rhs: A string containing the right-hand side of the expression.
+
+    Returns:
+        str: Containing the comparison expression.
+
+    References:
+        For more information on STIX2 patterning visit
+        http://docs.oasis-open.org/cti/stix/v2.0/cs01/part5-stix-patterning/stix-v2.0-cs01-part5-stix-patterning.html
+
+    '''
+    return '{lhs} {op} \'{rhs}\''.format(lhs=lhs, op=op, rhs=rhs)
+
+
+def create_sti2_observation_expression(comp_exps, obs_operator=None):
+    '''
+    Given comparison expression(s) create an observation expression.
+
+    Args:
+        comp_exps: a list of comparison expressions or single comparison
+            expression to generate an observation expression.
+        obs_operator: A observation operator (e.g., 'OR' or 'AND'). Required
+            when a list of comparison expressions is provided.
+
+    Returns:
+        A STIX2 comparison expression pattern.
+
+    References:
+        For more information on STIX2 patterning visit
+        http://docs.oasis-open.org/cti/stix/v2.0/cs01/part5-stix-patterning/stix-v2.0-cs01-part5-stix-patterning.html
+
+    '''
+    if isinstance(comp_exps, list) and len(comp_exps) > 1:
+        # The obs_operator is required for this operation.
+        return '[ {pattern} ]'.format(pattern=
+                                      join_stix2_comparison_expression(
+                                          comp_exps, obs_operator
+                                      ))
+    elif len(comp_exps) == 1:
+        return '[ {pattern} ]'.format(pattern=comp_exps[0])
+    return '[ {pattern} ]'.format(pattern=comp_exps)
+
+
+def extract_file_cuckoo(dropped_file):
+    '''
+    Process a Cuckoo dropped file obtained from analysis.
+
+    Args:
+        dropped_file: A dict from the "dropped" list from the "Cuckoo Sandbox"
+            report.
+
+    Returns:
+        ``stix2.Indicator`` with a pattern that matches the file by name or
+            a variety of hashes.
+
+    '''
+    labels = ['benign']
+    dropped_pattern = []
+
+    file_name = dropped_file.get('filepath', '')
+    sha1_value = dropped_file.get('sha1', '')
+    sha256_value = dropped_file.get('sha256', '')
+    md5_value = dropped_file.get('md5', '')
+
+    if file_name:
+        file_name = file_name.split("\\")[-1]
+        dropped_pattern.append(
+            create_stix2_comparison_expression('file:name', '=', file_name)
+        )
+
+    if sha1_value:
+        dropped_pattern.append(
+            create_stix2_comparison_expression('file:hashes.\'SHA-1\'', '=',
+                                               sha1_value)
+        )
+
+    if sha256_value:
+        dropped_pattern.append(
+            create_stix2_comparison_expression('file:hashes.\'SHA-256\'', '=',
+                                               sha256_value)
+        )
+
+    if md5_value:
+        dropped_pattern.append(
+            create_stix2_comparison_expression('file:hashes.\'MD5\'', '=',
+                                               md5_value)
+        )
+
+    return stix2.Indicator(**{
+        'labels': labels,
+        'pattern': create_sti2_observation_expression(dropped_pattern, 'OR')
+    })
+
+
+def extract_http_requests_cuckoo(marks_list, severity):
+    '''
+    Process Cuckoo http signatures obtained from analysis.
+
+    Args:
+        marks_list: A list of http marks from the "signatures" list in the
+            "Cuckoo Sandbox" report.
+        severity: The severity score from the "signatures". (range 1 to 3)
+
+    Returns:
+        list: Containing ``stix2.Indicator`` with a pattern that matches the
+            file by name or a variety of hashes.
+
+    '''
+    indicators = []
+    labels = []
+
+    if severity <= 2:
+        labels.extend(['benign', 'anomalous-activity'])
+    else:
+        labels.append('anomalous-activity')
+
+    for ioc_mark in marks_list:
+        ioc = ioc_mark.get('ioc', '')
+        if ioc:
+            url_value = ioc.split()[1]
+            ioc_pattern = create_sti2_observation_expression(
+                create_stix2_comparison_expression('url:value', '=', url_value)
+            )
+            indicators.append(stix2.Indicator(**{
+                'labels': labels,
+                'pattern': ioc_pattern
+            }))
+
+    return indicators
+
+
+def parse_json_report_to_stix2_bundle(report):
+    '''
+    Creates a STIX2 bundle from a multiscanner JSON report. This is achieved
+    on a best effort approach and does not intend to capture all possible
+    cases.
+
+    Args:
+        report: The dict representation of a multiscanner report.
+
+    Returns:
+        ``stix2.Bundle`` with Indicators generated from the report.
+
+    Notes:
+        There might be more content present in the report that may not
+        be represented as STIX simply because neccessary logic to process
+        that content is missing.
+
+    '''
+    all_objects = []
+    r = report.get('Report', {})
+
+    cuckoo = r.get('Cuckoo Sandbox', {})
+
+    for c in cuckoo:  # Use this block to extract further content from cuckoo
+        for signature in c.get('signatures', []):
+            if ('description' in signature
+                    and 'HTTP request' in signature.get('description', '')):
+                all_objects.extend(extract_http_requests_cuckoo(
+                    signature.get('marks', []),
+                    signature.get('severity', 1)
+                ))
+        for dropped in c.get('dropped', []):
+            if dropped and ('sha256', 'md5', 'sha1') in dropped:
+                all_objects.append(extract_file_cuckoo(dropped))
+
+    # Extract information from file submission and create Indicator
+    submission_pattern = []
+    file_name = r.get('filename', '')
+    sha1_value = r.get('SHA1', '')
+    sha256_value = r.get('SHA256', '')
+    md5_value = r.get('MD5', '')
+
+    if file_name:
+        submission_pattern.append(
+            create_stix2_comparison_expression('file:name', '=', file_name)
+        )
+
+    if sha1_value:
+        submission_pattern.append(
+            create_stix2_comparison_expression('file:hashes.\'SHA-1\'', '=',
+                                               sha1_value)
+        )
+
+    if sha256_value:
+        submission_pattern.append(
+            create_stix2_comparison_expression('file:hashes.\'SHA-256\'', '=',
+                                               sha256_value)
+        )
+
+    if md5_value:
+        submission_pattern.append(
+            create_stix2_comparison_expression('file:hashes.\'MD5\'', '=',
+                                               md5_value)
+        )
+
+    if submission_pattern:
+        all_objects.append(stix2.Indicator(**{
+            'labels': ['benign'],
+            'pattern': create_sti2_observation_expression(submission_pattern,
+                                                          'OR')
+        }))
+
+    return create_stix2_bundle(all_objects)

--- a/web/templates/report.html
+++ b/web/templates/report.html
@@ -497,6 +497,8 @@
         window.location = "{{ api_loc }}/api/v1/tasks/{{ task_id }}/maec";
       } else if (this.id == 'getPDF') {
         window.location = "{{ api_loc }}/api/v1/tasks/{{ task_id }}/pdf";
+      } else if (this.id == 'getSTIX2') {
+        window.location = "{{ api_loc }}/api/v1/tasks/{{ task_id }}/stix2?pretty=true";
       }
     });
   });
@@ -537,6 +539,7 @@
         <li id="getSample"><a href="#">Sample</a></li>
         <li id="getMAEC"><a href="#">MAEC</a></li>
         <li id="getPDF"><a href="#">PDF</a></li>
+        <li id="getSTIX2"><a href="#">STIX2</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This PR adds additional functionality by processing contents of a submission report and creating STIX2 Indicators from them. It currently generates content from:

- Cuckoo Sandbox output
- General submission information

There is still room to improve the STIX content generation.