### PR TITLE
Worker failure

### DIFF
--- a/tests/test_celery_worker.py
+++ b/tests/test_celery_worker.py
@@ -1,0 +1,127 @@
+import os
+import shutil
+import sys
+import json
+import mock
+import hashlib
+try:
+    from StringIO import StringIO as BytesIO
+except ImportError:
+    from io import BytesIO
+import unittest
+
+
+CWD = os.path.dirname(os.path.abspath(__file__))
+MS_WD = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Allow import of celery_worker.py
+if os.path.join(MS_WD, 'utils') not in sys.path:
+    sys.path.insert(0, os.path.join(MS_WD, 'utils'))
+if os.path.join(MS_WD, 'storage') not in sys.path:
+    sys.path.insert(0, os.path.join(MS_WD, 'storage'))
+# Use multiscanner in ../
+sys.path.insert(0, os.path.dirname(CWD))
+
+import elasticsearch
+elasticsearch.client.IndicesClient.exists_template = mock.MagicMock(return_value=True)
+elasticsearch.client.IngestClient.get_pipeline = mock.MagicMock(return_value=True)
+
+import celery_worker
+import multiscanner
+from sql_driver import Database
+
+
+TEST_DB_PATH = os.path.join(CWD, 'testing.db')
+if os.path.exists(TEST_DB_PATH):
+    os.remove(TEST_DB_PATH)
+DB_CONF = Database.DEFAULTCONF
+DB_CONF['db_name'] = TEST_DB_PATH
+
+## Metadata about test file
+TEST_FULL_PATH = os.path.join(CWD, 'files/123.txt')
+TEST_ORIGINAL_FILENAME = TEST_FULL_PATH.split('/')[-1]
+TEST_TASK_ID = 1
+with open(TEST_FULL_PATH, 'r') as f:
+    TEST_FILE_HASH = hashlib.sha256(f.read().encode('utf-8')).hexdigest()
+TEST_METADATA = {}
+TEST_CONFIG = multiscanner.CONFIG
+FOO_CONFIG = {
+    'main': {
+        'api-config': 'foo',
+        'web-config': 'bar',
+        'storage-config': 'baz',
+    },
+    'libmagic': True,
+    'entropy': True,
+    'mmbot': False,
+    'NSRL': False,
+    'fileextensions': False,
+    'officemeta': False,
+    'ssdeep': False,
+}
+
+
+TEST_REPORT = {
+    'MD5': '96b47da202ddba8d7a6b91fecbf89a41',
+    'SHA256': '26d11f0ea5cc77a59b6e47deee859440f26d2d14440beb712dbac8550d35ef1f',
+    'libmagic': 'a /bin/python script text executable',
+    'filename': '/opt/other_file'
+}
+
+
+def post_file(app):
+    return app.post(
+        '/api/v1/tasks',
+        data={'file': (BytesIO(b'my file contents'), 'hello world.txt'), })
+
+
+# def mock_delay(file_, original_filename, task_id, f_name, metadata, config):
+#     return TEST_REPORT
+
+
+class CeleryTestCase(unittest.TestCase):
+    def setUp(self):
+        self.sql_db = Database(config=DB_CONF)
+        self.sql_db.init_db()
+        # Replace the real production DB w/ a testing DB
+        celery_worker.db = self.sql_db
+
+    def tearDown(self):
+        # Clean up Test DB and upload folder
+        os.remove(TEST_DB_PATH)
+
+
+class TestCeleryCase(CeleryTestCase):
+    def setUp(self):
+        super(self.__class__, self).setUp()
+        # api.multiscanner_celery.delay = mock_delay
+
+    def test_base(self):
+        self.assertEqual(True, True)
+
+    @mock.patch('celery_worker.multiscanner_celery')
+    def test_success(self, mock_delay):
+        mock_delay.return_value = TEST_REPORT
+        result = celery_worker.multiscanner_celery(
+            file_=TEST_FULL_PATH,
+            original_filename=TEST_ORIGINAL_FILENAME,
+            task_id=1,
+            file_hash=TEST_FILE_HASH,
+            metadata=TEST_METADATA,
+            config=TEST_CONFIG
+        )
+        mock_delay.assert_called_once()
+        self.assertEqual(result, TEST_REPORT)
+
+    # TODO: patch storage_handler.store(result)
+    @mock.patch('celery_worker.multiscanner.storage.StorageHandler')
+    def test_delay_method(self, MockStorageHandler):
+        result = celery_worker.multiscanner_celery(
+            file_=TEST_FULL_PATH,
+            original_filename=TEST_ORIGINAL_FILENAME,
+            task_id=1,
+            file_hash=TEST_FILE_HASH,
+            metadata=TEST_METADATA,
+            config=FOO_CONFIG
+        )
+        print(result)

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -109,7 +109,7 @@ class MultiScannerTask(Task):
 
 
 @app.task(base=MultiScannerTask)
-def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, config=multiscanner.CONFIG):
+def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, config=multiscanner.CONFIG, module_list=None):
     '''
     Queue up multiscanner tasks
 
@@ -134,7 +134,10 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
     storage_conf = multiscanner.common.get_config_path(config, 'storage')
     storage_handler = multiscanner.storage.StorageHandler(configfile=storage_conf)
 
-    resultlist = multiscanner.multiscan(list(files), configfile=config)
+    resultlist = multiscanner.multiscan(list(files),
+        configfile=config,
+        module_list=module_list
+    )
     results = multiscanner.parse_reports(resultlist, python=True)
 
     scan_time = datetime.now().isoformat()

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -137,7 +137,8 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
     storage_conf = multiscanner.common.get_config_path(config, 'storage')
     storage_handler = multiscanner.storage.StorageHandler(configfile=storage_conf)
 
-    resultlist = multiscanner.multiscan(list(files),
+    resultlist = multiscanner.multiscan(
+        list(files),
         configfile=config,
         module_list=module_list
     )

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -155,7 +155,7 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
     total_modules = 0
     for key in sub_conf:
         total_modules += 1
-        if sub_conf[key]['ENABLED'] == True:
+        if sub_conf[key]['ENABLED'] is True:
             total_enabled += 1
 
     results[file_]['Scan Metadata'] = {}

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -124,21 +124,14 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
     # Initialize the connection to the task DB
     db.init_db()
 
-    files = {}
     logger.info('\n\n{}{}Got file: {}.\nOriginal filename: {}.\n'.format('='*48, '\n', file_hash, original_filename))
-    files[file_] = {
-        'original_filename': original_filename,
-        'task_id': task_id,
-        'file_hash': file_hash,
-        'metadata': metadata,
-    }
 
     # Get the storage config
     storage_conf = multiscanner.common.get_config_path(config, 'storage')
     storage_handler = multiscanner.storage.StorageHandler(configfile=storage_conf)
 
     resultlist = multiscanner.multiscan(
-        list(files),
+        [file_],
         configfile=config,
         module_list=module_list
     )

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -146,17 +146,15 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
     scan_config_object.read(config)
     full_conf = common.parse_config(scan_config_object)
     sub_conf = {}
+    # Count number of modules enabled out of total possible
+    # and add it to the Scan Metadata
+    total_enabled = 0
+    total_modules = 0
     for key in full_conf:
         if key == 'main':
             continue
         sub_conf[key] = {}
         sub_conf[key]['ENABLED'] = full_conf[key]['ENABLED']
-
-    # Count number of modules enabled out of total possible
-    # and add it to the Scan Metadata
-    total_enabled = 0
-    total_modules = 0
-    for key in sub_conf:
         total_modules += 1
         if sub_conf[key]['ENABLED'] is True:
             total_enabled += 1

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -80,7 +80,15 @@ def setup_periodic_tasks(sender, **kwargs):
 
 
 class MultiScannerTask(Task):
+    '''
+    Class of tasks that defines call backs to handle signals
+    from celery
+    '''
     def on_failure(self, exc, task_id, args, kwargs, einfo):
+        '''
+        When a task fails, update the task DB with a "Failed"
+        status. Dump a traceback to local logs
+        '''
         print('Task #{} failed'.format(args[2]))
         print('Traceback info:\n{}'.format(einfo))
 

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -69,6 +69,7 @@ app = Celery(broker='{0}://{1}:{2}@{3}/{4}'.format(
 app.conf.timezone = worker_config.get('tz')
 db = database.Database(config=db_config)
 
+
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
     # Executes every morning at 2:00 a.m.
@@ -76,6 +77,7 @@ def setup_periodic_tasks(sender, **kwargs):
         crontab(hour=2, minute=0),
         ssdeep_compare_celery.s(),
     )
+
 
 class MultiScannerTask(Task):
     def on_failure(self, exc, task_id, args, kwargs, einfo):
@@ -105,22 +107,6 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
     multiscanner_celery.delay(full_path, original_filename, task_id, metdata,
                               hashed_filename, metadata, config)
     '''
-
-    def on_failure(self, *args, **kwargs):
-        print('This task failed!')
-
-        # Initialize the connection to the task DB
-        db.init_db()
-
-        scan_time = datetime.now().isoformat()
-
-        # Update the task DB with the failure
-        db.update_task(
-            task_id=task_id,
-            task_status='Failed',
-            timestamp=scan_time,
-        )
-
     # Initialize the connection to the task DB
     db.init_db()
 

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -4,12 +4,17 @@ $ celery -A celery_worker worker
 from the utils/ directory.
 '''
 
-import os
-import sys
 import codecs
 import configparser
+import os
+import sys
 from datetime import datetime
 from socket import gethostname
+
+from celery import Celery, Task
+from celery.schedules import crontab
+from celery.utils.log import get_task_logger
+
 MS_WD = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Append .. to sys path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -22,14 +27,12 @@ if os.path.join(MS_WD, 'libs') not in sys.path:
 # Add the analytics dir to the sys.path. Allows import of ssdeep_analytics
 if os.path.join(MS_WD, 'analytics') not in sys.path:
     sys.path.insert(0, os.path.join(MS_WD, 'analytics'))
-import multiscanner
+
 import common
+import multiscanner
 import sql_driver as database
 from ssdeep_analytics import SSDeepAnalytic
 
-from celery import Celery, Task
-from celery.schedules import crontab
-from celery.utils.log import get_task_logger
 
 logger = get_task_logger(__name__)
 

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -118,8 +118,8 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
 
     Usage:
     from celery_worker import multiscanner_celery
-    multiscanner_celery.delay(full_path, original_filename, task_id, metdata,
-                              hashed_filename, metadata, config)
+    multiscanner_celery.delay(full_path, original_filename, task_id,
+                              hashed_filename, metadata, config, module_list)
     '''
     # Initialize the connection to the task DB
     db.init_db()

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -148,9 +148,22 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
             continue
         sub_conf[key] = {}
         sub_conf[key]['ENABLED'] = full_conf[key]['ENABLED']
+
+    # Count number of modules enabled out of total possible
+    # and add it to the Scan Metadata
+    total_enabled = 0
+    total_modules = 0
+    for key in sub_conf:
+        total_modules += 1
+        if sub_conf[key]['ENABLED'] == True:
+            total_enabled += 1
+
     results[file_]['Scan Metadata'] = {}
     results[file_]['Scan Metadata']['Worker Node'] = gethostname()
     results[file_]['Scan Metadata']['Scan Config'] = sub_conf
+    results[file_]['Scan Metadata']['Modules Enabled'] = '{} / {}'.format(
+        total_enabled, total_modules
+    )
 
     # Use the original filename as the value for the filename
     # in the report (instead of the tmp path assigned to the file

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -188,6 +188,7 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
 
     return results
 
+
 @app.task()
 def ssdeep_compare_celery():
     '''

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -167,8 +167,6 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
     results[original_filename]['Scan Time'] = scan_time
     results[original_filename]['Metadata'] = metadata
 
-    raise Exception('FOO!')
-
     # Update the task DB to reflect that the task is done
     db.update_task(
         task_id=task_id,

--- a/web/templates/analyses.html
+++ b/web/templates/analyses.html
@@ -33,11 +33,7 @@
       },
       columnDefs: [
         {
-          targets: 2,
-          data: 3,
-        },
-        {
-          targets: 3,
+          targets: 4,
           searchable: false,
           orderable: false,
           data: null,
@@ -194,7 +190,8 @@
       <thead>
         <tr>
           <th width="5%">Task ID</th>
-          <th width="72%">Sample</th>
+          <th width="60%">Sample</th>
+          <th width="12%">Task Status</th>
           <th width="17%">Timestamp</th>
           <th class="text-center" width="6%">Delete</th>
         </tr>

--- a/web/templates/analyses.html
+++ b/web/templates/analyses.html
@@ -50,9 +50,11 @@
       ],
       rowCallback: function( row, data, index ) {
         if (data[2] == "Complete") {
-          tr_class = ""
+          tr_class = "";
+        } else if (data[2] == "Failed") {
+            tr_class = " danger";
         } else {
-          tr_class = " warning"
+          tr_class = " warning";
         }
         $(row).addClass("task-row" + tr_class);
         $(row).attr('data-href', '/report/' + data[0]);

--- a/web/templates/history.html
+++ b/web/templates/history.html
@@ -49,9 +49,11 @@
           data[3] = data[3].replace(' ', 'T');
         }
         if (data[2] == "Complete") {
-          tr_class = ""
+          tr_class = "";
+        } else if (data[2] == "Failed") {
+            tr_class = " danger";
         } else {
-          tr_class = " warning"
+          tr_class = " warning";
         }
         $(row).addClass("task-row" + tr_class);
         $(row).attr('data-href', '/report/' + data[0]);


### PR DESCRIPTION
This PR:
* Allows celery workers to gracefully handle failures.
* Removes the batching from the celery worker, which isn't officially supported by Celery at the moment. This will (hopefully) allow us to add per sample scan configurations. It also makes for a much cleaner code base.