### PR TITLE
Add flake8 to CI and bring everything in line with pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ install:
   - pip install -r requirements.txt
   - python multiscanner.py init
 script:
+  - flake8 .
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ install:
   - pip install -r requirements.txt
   - python multiscanner.py init
 script:
-  - flake8 .
+  - flake8 --exit-zero .
   - pytest

--- a/modules/Antivirus/VFindScan.py
+++ b/modules/Antivirus/VFindScan.py
@@ -12,14 +12,13 @@ Configuration options:
     `vfind_cmdline' - additional command line options for VFind
 
 Additional notes:
-    The UAD tool is run a second time here instead of using data directly from the UADScan metadata 
+    The UAD tool is run a second time here instead of using data directly from the UADScan metadata
     module. This is done for simplicity and should not adversely effect performance. Note that UAD
     does not perform file expansion again when used in this module.
 '''
 
 import os
 import re
-import sys
 import subprocess
 
 __author__ = "Alec Hussey"
@@ -29,53 +28,58 @@ TYPE = "Antivirus"
 NAME = "VFind"
 
 DEFAULTCONF = {
-	"ENABLED": False,
-	"vstk_home": "/opt/vstk",
-	"uad_cmdline": [],
-	"vfind_cmdline": []
+    "ENABLED": False,
+    "vstk_home": "/opt/vstk",
+    "uad_cmdline": [],
+    "vfind_cmdline": []
 }
 
+
 def check(conf=DEFAULTCONF):
-	if not conf['ENABLED']:
-		return False
-	if not os.path.isdir(conf['vstk_home']):
-		return False
-	return True
+    if not conf['ENABLED']:
+        return False
+    if not os.path.isdir(conf['vstk_home']):
+        return False
+    return True
+
 
 def scan(filelist, conf=DEFAULTCONF):
-	results = []
-	uad_command = [os.path.join(conf['vstk_home'], "bin/uad"), "-n", "-ssw"] + conf['uad_cmdline'] + filelist
-	vfind_command = [os.path.join(conf['vstk_home'], "bin/vfind"), "-ssr"] + conf['vfind_cmdline']
+    results = []
+    uad_command = [os.path.join(conf['vstk_home'], "bin/uad"), "-n", "-ssw"] + conf['uad_cmdline'] + filelist
+    vfind_command = [os.path.join(conf['vstk_home'], "bin/vfind"), "-ssr"] + conf['vfind_cmdline']
 
-	try:
-		uad = subprocess.Popen(uad_command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-		vfind = subprocess.Popen(vfind_command, stdin=uad.stdout, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-		output = vfind.communicate(timeout=21600)[0].decode("utf-8", errors="replace")
-	except subprocess.CalledProcessError as error:
-		return None
+    try:
+        uad = subprocess.Popen(uad_command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        vfind = subprocess.Popen(vfind_command, stdin=uad.stdout, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        output = vfind.communicate(timeout=21600)[0].decode("utf-8", errors="replace")
+    except subprocess.CalledProcessError as error:
+        return None
 
-	results = re.findall("^##==>>>> VIRUS POSSIBLE IN FILE: \"(.+)\"\n##==>>>> VIRUS ID: (\w+ .+)", output, re.MULTILINE)
+    results = re.findall("^##==>>>> VIRUS POSSIBLE IN FILE: \"(.+)\"\n##==>>>> VIRUS ID: (\w+ .+)",
+                         output,
+                         re.MULTILINE)
 
-	vfind_version = ""
-	try:
-		vfind_version = re.search("^##==> VFind Version: (\d+), Release: (\d+), Patchlevel: (\d+) .+", output)
-		vfind_version = "{}.{}.{}".format(
-			vfind_version.group(1), 
-			vfind_version.group(2), 
-			vfind_version.group(3)
-		)
-	except:
-		pass
+    vfind_version = ""
+    try:
+        vfind_version = re.search("^##==> VFind Version: (\d+), Release: (\d+), Patchlevel: (\d+) .+", output)
+        vfind_version = "{}.{}.{}".format(
+            vfind_version.group(1),
+            vfind_version.group(2),
+            vfind_version.group(3)
+        )
+    except Exception as e:
+        # TODO: log exception
+        pass
 
-	vdl_version = ""
-	with open(os.path.join(conf['vstk_home'], "data/vfind/VERSION"), "r") as vdl_version_file:
-		vdl_version = vdl_version_file.read().strip()
+    vdl_version = ""
+    with open(os.path.join(conf['vstk_home'], "data/vfind/VERSION"), "r") as vdl_version_file:
+        vdl_version = vdl_version_file.read().strip()
 
-	metadata = {
-		"Type": TYPE,
-		"Name": NAME,
-		"Program version": vfind_version,
-		"Definition version": vdl_version
-	}
+    metadata = {
+        "Type": TYPE,
+        "Name": NAME,
+        "Program version": vfind_version,
+        "Definition version": vdl_version
+    }
 
-	return (results, metadata)
+    return (results, metadata)

--- a/modules/MachineLearning/MaliciousMacroBot.py
+++ b/modules/MachineLearning/MaliciousMacroBot.py
@@ -11,12 +11,12 @@ NAME = "MaliciousMacroBot"
 REQUIRES = ['libmagic']
 DEFAULTCONF = {
     'ENABLED': False
-    }
+}
 
 try:
     from mmbot import MaliciousMacroBot
     has_mmbot = True
-except:
+except ImportError as e:
     print("mmbot module not installed...")
     has_mmbot = False
 

--- a/modules/Metadata/fileextensions.py
+++ b/modules/Metadata/fileextensions.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
-import json
+
 import mimetypes
 
 __author__ = 'Austin West'
@@ -13,7 +13,7 @@ NAME = 'fileextensions'
 REQUIRES = ['libmagic', 'Tika', 'TrID', 'vtsearch']
 DEFAULTCONF = {
     'ENABLED': True
-    }
+}
 
 EXTENSION_BLACKLIST = [
     '.virus',
@@ -94,12 +94,12 @@ def _get_tridresults(results, fname):
     # pull out all the possible extensions. Then,
     # make them all lowercase and de-duplicate them.
     triddict = dict(results)
-    result = []  
+    result = []
     for tridresult in triddict.get(fname):
         result.append(tridresult[2].lower())
     # make trid results unique
     result = list(set(result))
-    return result 
+    return result
 
 
 def _get_vtresults(results, fname):
@@ -114,7 +114,7 @@ def _get_vtresults(results, fname):
             if extension not in EXTENSION_BLACKLIST:
                 result.append(extension)
     result = list(set(result))
-    return result 
+    return result
 
 
 def _convert_libmagic_to_extension(libmagicresult):

--- a/modules/Metadata/impfuzzy.py
+++ b/modules/Metadata/impfuzzy.py
@@ -4,13 +4,10 @@
 from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
 try:
     import pyimpfuzzy
-except:
+except ImportError as e:
     print("pyimpfuzzy module not installed...")
     pyimpfuzzy = False
 
-from common import hashfile
-import hashlib
-import time
 import sys
 
 PY3 = False
@@ -28,12 +25,14 @@ DEFAULTCONF = {
     'ENABLED': True,
 }
 
+
 def check(conf=DEFAULTCONF):
     if not conf['ENABLED'] or \
        not pyimpfuzzy or \
        None in REQUIRES:
         return False
     return True
+
 
 def scan(filelist, conf=DEFAULTCONF):
     results = []
@@ -63,4 +62,3 @@ def scan(filelist, conf=DEFAULTCONF):
     metadata["Type"] = TYPE
     metadata["Include"] = False
     return (results, metadata)
-

--- a/modules/Metadata/officemeta.py
+++ b/modules/Metadata/officemeta.py
@@ -1,8 +1,16 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from __future__ import division, absolute_import, with_statement, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals, with_statement)
+
+import binascii
 import sys
+import traceback
+from builtins import *  # noqa 401,403
+
+from office_meta import OfficeParser
+
 PY3 = False
 if sys.version_info > (3,):
     PY3 = True
@@ -11,20 +19,13 @@ __author__ = "Patrick Coplenad"
 __credits__ = ["Mike Goffin"]
 __license__ = "MPL 2.0"
 
-from builtins import *
-import hashlib
-import math
-import re
-import traceback
-import binascii
-from office_meta import OfficeParser
-
 TYPE = "Metadata"
 NAME = "officemeta"
 REQUIRES = ["libmagic"]
 DEFAULTCONF = {
     'ENABLED': True,
-    }
+}
+
 
 def check(conf=DEFAULTCONF):
     if not conf['ENABLED']:
@@ -32,6 +33,7 @@ def check(conf=DEFAULTCONF):
     if None in REQUIRES:
         return False
     return True
+
 
 def scan(filelist, conf=DEFAULTCONF):
     results = []
@@ -44,7 +46,7 @@ def scan(filelist, conf=DEFAULTCONF):
                     ret = run(fh.read())
             except Exception as e:
                 print('officemeta', e)
-                traceback.print_exc(file=sys.stdout) 
+                traceback.print_exc(file=sys.stdout)
             if ret:
                 results.append((fname, ret))
 
@@ -53,6 +55,7 @@ def scan(filelist, conf=DEFAULTCONF):
     metadata["Type"] = TYPE
     metadata["Include"] = False
     return (results, metadata)
+
 
 def run(data):
     ret = {}
@@ -68,10 +71,10 @@ def run(data):
 
     for curr_dir in oparser.directory:
         result = {
-            'md5':          curr_dir.get('md5', ''),
-            'size':         curr_dir.get('stream_size', 0),
-            'mod_time':     oparser.timestamp_string(curr_dir['modify_time'])[1],
-            'create_time':  oparser.timestamp_string(curr_dir['create_time'])[1],
+            'md5': curr_dir.get('md5', ''),
+            'size': curr_dir.get('stream_size', 0),
+            'mod_time': oparser.timestamp_string(curr_dir['modify_time'])[1],
+            'create_time': oparser.timestamp_string(curr_dir['create_time'])[1],
         }
         name = curr_dir['norm_name'].decode('ascii', errors='ignore')
         # TODO: why is this '' sometimes?
@@ -84,12 +87,12 @@ def run(data):
         for prop in prop_list['property_list']:
             prop_summary = oparser.summary_mapping.get(binascii.unhexlify(prop['clsid']), None)
             prop_name = prop_summary.get('name', 'Unknown')
-            if not prop_name in ret['doc_meta']:
+            if prop_name not in ret['doc_meta']:
                 ret['doc_meta'][prop_name] = {}
             for item in prop['properties']['properties']:
                 result = {
-                    'name':		item.get('name', 'Unknown'),
-                    'value':	item.get('date', item['value']),
+                    'name': item.get('name', 'Unknown'),
+                    'value': item.get('date', item['value']),
                 }
-                ret['doc_meta'][prop_name][result.get('name')] = result.get('value') 
+                ret['doc_meta'][prop_name][result.get('name')] = result.get('value')
     return ret

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ pytest
 mock
 selenium
 #Requred by dev
+flake8
 pre-commit
 #Required by utils
 tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,4 @@ tag = False
 [flake8]
 ignore = E126,E127,E128,E402
 max-line-length = 120
-exclude = .git,__pycache__,libs/pdfparser.py
+exclude = .git,__pycache__,libs/pdfparser.py,libs/office_meta.py

--- a/storage/basic_elasticsearch_storage.py
+++ b/storage/basic_elasticsearch_storage.py
@@ -2,7 +2,9 @@
 Storage module that will interact with elasticsearch in a simple way.
 """
 from uuid import uuid4
-from elasticsearch import Elasticsearch, helpers
+
+from elasticsearch import Elasticsearch
+
 import storage
 
 
@@ -50,7 +52,7 @@ class BasicElasticSearchStorage(storage.Storage):
                 }
             )
 
-        result = helpers.bulk(self.es, report_list)
+        # result = helpers.bulk(self.es, report_list)
         return report_id_list
 
     def teardown(self):
@@ -70,7 +72,7 @@ class BasicElasticSearchStorage(storage.Storage):
                 dictionary[new_key] = dictionary[key]
                 del dictionary[key]
                 if not self.warned_renamed:
-                    print('WARNING: Some keys had a . in their name which was replaced with a _' )
+                    print('WARNING: Some keys had a . in their name which was replaced with a _')
                     self.warned_renamed = True
         return dictionary
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -7,6 +7,7 @@ import requests
 
 # https://realpython.com/blog/python/testing-third-party-apis-with-mock-servers/
 
+
 class MockHTTPServerRequestHandler(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self):
@@ -48,12 +49,14 @@ class MockHTTPServerRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(response_content.encode('utf-8'))
         return
 
+
 def get_free_server_port():
     s = socket.socket(socket.AF_INET, type=socket.SOCK_STREAM)
     s.bind(('localhost', 0))
     address, port = s.getsockname()
     s.close()
     return port
+
 
 def start_mock_server(port=8080):
     mock_server = HTTPServer(('localhost', port), MockHTTPServerRequestHandler)

--- a/tests/test_celery_worker.py
+++ b/tests/test_celery_worker.py
@@ -1,14 +1,19 @@
-import os
-import shutil
-import sys
-import json
-import mock
 import hashlib
+import os
+import sys
+import unittest
+
+import mock
+import multiscanner
+
+import celery_worker
+import common
+from sql_driver import Database
+
 try:
     from StringIO import StringIO as BytesIO
 except ImportError:
     from io import BytesIO
-import unittest
 
 
 CWD = os.path.dirname(os.path.abspath(__file__))
@@ -24,12 +29,6 @@ if os.path.join(MS_WD, 'libs') not in sys.path:
 
 # Use multiscanner in ../
 sys.path.insert(0, os.path.dirname(CWD))
-
-import common
-import celery_worker
-import multiscanner
-from sql_driver import Database
-
 
 # Get a subset of simple modules to run in testing
 # the celery worker
@@ -52,7 +51,7 @@ if os.path.exists(TEST_DB_PATH):
 DB_CONF = Database.DEFAULTCONF
 DB_CONF['db_name'] = TEST_DB_PATH
 
-## Metadata about test file
+# Metadata about test file
 TEST_FULL_PATH = os.path.join(CWD, 'files/123.txt')
 TEST_ORIGINAL_FILENAME = TEST_FULL_PATH.split('/')[-1]
 TEST_TASK_ID = 1

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,4 +1,3 @@
-import json
 import os
 import requests
 import sys
@@ -6,7 +5,7 @@ import time
 
 import pytest
 
-from flask import Flask, url_for
+from flask import url_for
 from flask_testing import LiveServerTestCase
 from mocks import get_free_server_port, start_mock_server
 from pathlib import Path
@@ -30,8 +29,8 @@ sys.path.insert(0, os.path.dirname(CWD))
 from app import app as flask_app
 
 proxies = {
-  "http": None,
-  "https": None,
+    "http": None,
+    "https": None,
 }
 
 try:

--- a/utils/celery_worker.py
+++ b/utils/celery_worker.py
@@ -112,7 +112,8 @@ class MultiScannerTask(Task):
 
 
 @app.task(base=MultiScannerTask)
-def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, config=multiscanner.CONFIG, module_list=None):
+def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata,
+                        config=multiscanner.CONFIG, module_list=None):
     '''
     Queue up multiscanner tasks
 
@@ -124,7 +125,7 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
     # Initialize the connection to the task DB
     db.init_db()
 
-    logger.info('\n\n{}{}Got file: {}.\nOriginal filename: {}.\n'.format('='*48, '\n', file_hash, original_filename))
+    logger.info('\n\n{}{}Got file: {}.\nOriginal filename: {}.\n'.format('=' * 48, '\n', file_hash, original_filename))
 
     # Get the storage config
     storage_conf = multiscanner.common.get_config_path(config, 'storage')
@@ -188,6 +189,7 @@ def multiscanner_celery(file_, original_filename, task_id, file_hash, metadata, 
     logger.info('Completed Task #{}'.format(task_id))
 
     return results
+
 
 @app.task()
 def ssdeep_compare_celery():

--- a/utils/nsrl_parse.py
+++ b/utils/nsrl_parse.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from __future__ import (absolute_import, division, print_function,
                         with_statement)
+
 import argparse
 import codecs
 import csv
@@ -11,10 +12,10 @@ import sys
 
 from tqdm import tqdm
 
-
 PY3 = False
 if sys.version_info[:1] == (3,):
     PY3 = True
+
 
 def count_lines(path):
     lines = 0
@@ -33,6 +34,7 @@ def unicode_csv_reader(unicode_csv_data, dialect=csv.excel, **kwargs):
                             dialect=dialect, **kwargs)
     for row in csv_reader:
         # decode UTF-8 back to Unicode, cell by cell:
+        # TODO: Is this py3 compatible?
         yield [unicode(cell, 'utf-8') for cell in row]
 
 

--- a/utils/nsrl_parse.py
+++ b/utils/nsrl_parse.py
@@ -35,7 +35,7 @@ def unicode_csv_reader(unicode_csv_data, dialect=csv.excel, **kwargs):
     for row in csv_reader:
         # decode UTF-8 back to Unicode, cell by cell:
         # TODO: Is this py3 compatible?
-        yield [unicode(cell, 'utf-8') for cell in row]
+        yield [unicode(cell, 'utf-8') for cell in row]  # noqa: F821; protected by PY3 check
 
 
 def utf_8_encoder(unicode_csv_data):


### PR DESCRIPTION
Some things had been committed directly to master (instead of feature-celery) and didn't get the pep8 cleanup. This brings everything in master in line with our flake8 config _except for_ [this](https://github.com/ptcNOP/multiscanner/blob/1c05909c4a699addd202b3cb2ca43a6147eea84a/utils/nsrl_parse.py#L33). ~~, which I don't think is actually py3 compatible.~~