### PR TITLE
Fixed NSRL installation issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ if [[ $prompt == "y" ]]; then
   curl -k https://s3.amazonaws.com/rds.nsrl.nist.gov/RDS/current/rds_modernu.zip > rds_modernu.zip
   unzip rds_modernu.zip
   rm rds_modernu.zip
-  python $DIR/utils/nsrl_parse.py -o $DIR/etc/nsrl RDS_*/NSRLFile.txt
+  python $DIR/utils/nsrl_parse.py -o $DIR/etc/nsrl rds_*/NSRLFile.txt
   rm -fr RDS_*
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,7 @@ if [[ $prompt == "y" ]]; then
   unzip rds_modernu.zip
   rm rds_modernu.zip
   python $DIR/utils/nsrl_parse.py -o $DIR/etc/nsrl rds_*/NSRLFile.txt
-  rm -fr RDS_*
+  rm -fr rds_*
 fi
 
 read -p "Would you like to install MultiScanner as a system library? <y/N> " prompt

--- a/utils/nsrl_parse.py
+++ b/utils/nsrl_parse.py
@@ -78,7 +78,7 @@ def parse_nsrl(input_file, output_dir):
                     last = offset_val
                 output.write(line[0].lower() + '\t')
                 output.write(line[1].lower() + '\t')
-                output.write(line[3])
+                output.write(line[3].encode('utf-8'))
                 count += 1
 
 

--- a/utils/nsrl_parse.py
+++ b/utils/nsrl_parse.py
@@ -44,7 +44,7 @@ def utf_8_encoder(unicode_csv_data):
 
 
 def parse_nsrl(input_file, output_dir):
-    output = open(os.path.join(output_dir, 'hash_list'), 'w')
+    output = codecs.open(os.path.join(output_dir, 'hash_list'), 'w', 'utf-8')
     offset = open(os.path.join(output_dir, 'offsets'), 'wb')
 
     offset_size = 5
@@ -78,7 +78,7 @@ def parse_nsrl(input_file, output_dir):
                     last = offset_val
                 output.write(line[0].lower() + '\t')
                 output.write(line[1].lower() + '\t')
-                output.write(line[3].encode('utf-8'))
+                output.write(line[3])
                 count += 1
 
 


### PR DESCRIPTION
I have encountered following errors during installation with the current rds_modernu.zip.
Please review this patch.

```
  File "/home/rtsuruta/multiscanner/utils/nsrl_parse.py", line 61, in parse_nsrl
    with codecs.open(input_file, 'r', 'utf-8', errors='replace') as f:
  File "/usr/lib64/python2.7/codecs.py", line 881, in open
    file = __builtin__.open(filename, mode, buffering)
IOError: [Errno 2] No such file or directory: 'RDS_*/NSRLFile.txt'
```
```
  File "utils/nsrl_parse.py", line 81, in parse_nsrl
    output.write(line[3])
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf8' in position 5: ordinal not in range(128)
```
