### PR TITLE
Disable by default modules using third-party tools

### DIFF
--- a/docs/custom/example.rst
+++ b/docs/custom/example.rst
@@ -12,7 +12,7 @@ Example Module
    NAME = "include example"
    REQUIRES = ["libmagic", "MD5"]
    DEFAULTCONF = {
-       'ENABLED': True,
+       'ENABLED': False,
    }
 
    def check(conf=DEFAULTCONF):

--- a/multiscanner/modules/Antivirus/AVGScan.py
+++ b/multiscanner/modules/Antivirus/AVGScan.py
@@ -30,7 +30,7 @@ DEFAULTCONF = {
     "cmdline": ['/A', '/H', '/PRIORITY=High'],
     "host": HOST,
     "replacement path": PATHREPLACE,
-    "ENABLED": True
+    "ENABLED": False
 }
 
 

--- a/multiscanner/modules/Antivirus/ClamAVScan.py
+++ b/multiscanner/modules/Antivirus/ClamAVScan.py
@@ -12,7 +12,7 @@ __author__ = 'Mike Long'
 __license__ = "MPL 2.0"
 
 DEFAULTCONF = {
-    "ENABLED": True,
+    "ENABLED": False,
 }
 
 

--- a/multiscanner/modules/Antivirus/MSEScan.py
+++ b/multiscanner/modules/Antivirus/MSEScan.py
@@ -28,7 +28,7 @@ DEFAULTCONF = {
     "cmdline": ["-Scan", "-ScanType", "3", "-DisableRemediation", "-File"],
     'host': HOST,
     "replacement path": PATHREPLACE,
-    'ENABLED': True
+    'ENABLED': False
 }
 
 

--- a/multiscanner/modules/Antivirus/McAfeeScan.py
+++ b/multiscanner/modules/Antivirus/McAfeeScan.py
@@ -29,7 +29,7 @@ DEFAULTCONF = {
     "cmdline": ["/ALL"],
     "host": HOST,
     "replacement path": PATHREPLACE,
-    "ENABLED": True
+    "ENABLED": False
 }
 
 

--- a/multiscanner/modules/Metadata/ExifToolsScan.py
+++ b/multiscanner/modules/Metadata/ExifToolsScan.py
@@ -31,7 +31,7 @@ DEFAULTCONF = {
     "host": HOST,
     "replacement path": PATHREPLACE,
     "remove-entry": REMOVEENTRY,
-    "ENABLED": True
+    "ENABLED": False
 }
 
 

--- a/multiscanner/modules/Metadata/TrID.py
+++ b/multiscanner/modules/Metadata/TrID.py
@@ -26,7 +26,7 @@ KEY = os.path.join(os.path.split(CONFIG)[0], 'etc', 'id_rsa')
 PATHREPLACE = "X:\\"
 DEFAULTCONF = {
     "path": '/opt/trid/trid',
-    'ENABLED': True,
+    'ENABLED': False,
     "key": KEY,
     "cmdline": ['-r:3'],
     'host': HOST,


### PR DESCRIPTION
Doesn't make sense to run them if the user doesn't have the tool installed.