### PR TITLE
Speed up ElasticSearch tests

### DIFF
--- a/multiscanner/tests/test_elasticsearch.py
+++ b/multiscanner/tests/test_elasticsearch.py
@@ -20,9 +20,10 @@ TEST_TS = "2017-09-26T16:48:05.395004"
 
 
 class TestES(unittest.TestCase):
+    @classmethod
     @mock.patch.object(IndicesClient, 'exists_template')
     @mock.patch.object(IngestClient, 'get_pipeline')
-    def setUp(self, mock_pipe, mock_exists):
+    def setUpClass(self, mock_pipe, mock_exists):
         mock_pipe.return_value = True
         mock_exists.return_value = True
         self.handler = ElasticSearchStorage(config=ElasticSearchStorage.DEFAULTCONF)
@@ -225,5 +226,6 @@ class TestES(unittest.TestCase):
         self.assertEqual(doc_type, '_doc')
         self.assertEqual(report_id, TEST_ID)
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(self):
         self.handler.teardown()


### PR DESCRIPTION
This is done by using the same ElasticSearch handler for all the tests instead of setting up a new one for each test. I was getting annoyed by ElasticSearchStorage.setup() slowing down testing.

Using these changes, `pytest multiscanner/tests/test_elasticsearch.py` went from
```12 passed, 1 warnings in 264.63 seconds```
to
```12 passed, 1 warnings in 22.33 seconds```