### PR TITLE
API Multiple Document Import APIv2

### DIFF
--- a/multiscanner/common/pdf_generator/__init__.py
+++ b/multiscanner/common/pdf_generator/__init__.py
@@ -77,7 +77,7 @@ def create_pdf_document(DIR, report):
     # -- end filemeata --
 
     if 'ssdeep' in report:
-        file_data.append(['SSDEEP', report.get('ssdeep', {}).get('ssdeep_hash', '')])
+        file_data.append(['SSDEEP', report.get('filemeta', {}).get('ssdeep', '')])
 
     if 'Yara' in report:
         for v in report.get('Yara', {}):

--- a/multiscanner/common/stix2_generator/__init__.py
+++ b/multiscanner/common/stix2_generator/__init__.py
@@ -257,7 +257,7 @@ def create_stix2_from_json_report(report, custom_labels=None):
     sha1_value = report.get('filemeta', {}).get('sha1', '')
     sha256_value = report.get('filemeta', {}).get('sha256', '')
     md5_value = report.get('filemeta', {}).get('md5', '')
-    ssdeep_value = report.get('ssdeep')
+    ssdeep_value = report.get('filemeta', {}).get('ssdeep', '')
 
     if file_name:
         submission_pattern.append(
@@ -282,10 +282,10 @@ def create_stix2_from_json_report(report, custom_labels=None):
                                                md5_value)
         )
 
-    if ssdeep_value and ssdeep_value.get('ssdeep_hash', ''):
+    if ssdeep_value:
         submission_pattern.append(
             create_stix2_comparison_expression('file:hashes.\'ssdeep\'', '=',
-                                               ssdeep_value.get('ssdeep_hash'))
+                                               ssdeep_value)
         )
 
     if submission_pattern:

--- a/multiscanner/distributed/api.py
+++ b/multiscanner/distributed/api.py
@@ -430,7 +430,9 @@ class InvalidScanTimeFormatError(ValueError):
 def insert_report(report):
     '''Inserts the report to the backend storage and returns an id'''
     try:
-        report['Scan Metadata']['Scan Time'] = datetime.strptime(report['Scan Metadata']['Scan Time'], '%Y-%m-%dT%H:%M:%S.%f')
+        report['Scan Metadata']['Scan Time'] = datetime.strptime(
+            report['Scan Metadata']['Scan Time'], '%Y-%m-%dT%H:%M:%S.%f'
+        )
     except ValueError as e:
         logger.debug(e)
         raise InvalidScanTimeFormatError()

--- a/multiscanner/distributed/api.py
+++ b/multiscanner/distributed/api.py
@@ -436,7 +436,7 @@ def import_task(file_):
     try:
         sample_id = report['filemeta']['sha256']
     except KeyError:
-        logger.warn("Unable to find sha256 hash for sample_id")
+        logger.warning("Unable to find sha256 hash for sample_id")
         sample_id = uuid4()
 
     task_id = db.add_task(

--- a/multiscanner/distributed/api.py
+++ b/multiscanner/distributed/api.py
@@ -720,13 +720,13 @@ def _pre_process(report_dict):
     # TODO: create way to mark certain data as internal only (e.g., does
     # not need to be part of generated report)
     # pop unnecessary keys
-    if report_dict.get('Report', {}).get('ssdeep', {}):
+    if report_dict.get('ssdeep_analytics', {}):
         for k in ['chunksize', 'chunk', 'double_chunk']:
-            report_dict['Report']['ssdeep'].pop(k, None)
+            report_dict['ssdeep_analytics'].pop(k, None)
 
-    if report_dict.get('Report', {}).get('impfuzzy', {}):
+    if report_dict.get('impfuzzy', {}):
         for k in ['chunksize', 'chunk', 'double_chunk']:
-            report_dict['Report']['impfuzzy'].pop(k, None)
+            report_dict['impfuzzy'].pop(k, None)
 
     report_dict = _add_links(report_dict)
 
@@ -741,9 +741,11 @@ def _add_links(report_dict):
 
     web_loc = api_config['api']['web_loc']
 
+    if web_loc.endswith('/'):
+        web_loc = web_loc.rstrip('/')
+
     # ssdeep matches
-    matches_dict = report_dict.get('Report', {}) \
-                              .get('ssdeep', {}) \
+    matches_dict = report_dict.get('ssdeep_analytics', {}) \
                               .get('matches', {})
 
     if matches_dict:
@@ -759,7 +761,7 @@ def _add_links(report_dict):
                 links_dict[k] = v
 
         # replace with updated dict
-        report_dict['Report']['ssdeep']['matches'] = links_dict
+        report_dict['ssdeep_analytics']['matches'] = links_dict
 
     return report_dict
 
@@ -906,7 +908,7 @@ def get_report_dict(task_id):
         if result:
             return result
         else:
-            abort(HTTP_SERVER_FAILED, 'Error occured in ElasticSearch')
+            abort(HTTP_SERVER_FAILED, 'Error occurred in ElasticSearch')
     elif task.task_status == 'Pending':
         return TASK_STILL_PROCESSING
     else:

--- a/multiscanner/distributed/api.py
+++ b/multiscanner/distributed/api.py
@@ -437,7 +437,7 @@ def import_task(file_):
         sample_id = report['filemeta']['sha256']
     except KeyError:
         logger.warning("Unable to find sha256 hash for sample_id")
-        sample_id = uuid4()
+        sample_id = str(uuid4())
 
     task_id = db.add_task(
         sample_id=sample_id,

--- a/multiscanner/modules/metadata/fileextensions.py
+++ b/multiscanner/modules/metadata/fileextensions.py
@@ -67,7 +67,8 @@ def scan(filelist, conf=DEFAULTCONF):
             result['trid'] = tridr
         if vtr:
             result['vt'] = vtr
-        results.append((fname, result))
+        if result:
+            results.append((fname, result))
 
     metadata = {}
     metadata['Name'] = NAME

--- a/multiscanner/modules/metadata/filemeta.py
+++ b/multiscanner/modules/metadata/filemeta.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 try:
     import magic
 except ImportError:
-    logger.warn("python-magic module not installed...")
+    logger.warning("python-magic module not installed...")
     magic = False
 
 __author__ = "Patrick Copeland"

--- a/multiscanner/modules/metadata/filemeta.py
+++ b/multiscanner/modules/metadata/filemeta.py
@@ -17,6 +17,13 @@ except ImportError:
     logger.warning("python-magic module not installed...")
     magic = False
 
+try:
+    import ssdeep
+except ImportError:
+    logger.warning("ssdeep module not installed...")
+    ssdeep = False
+
+
 __author__ = "Patrick Copeland"
 __license__ = "MPL 2.0"
 
@@ -53,6 +60,10 @@ def scan(filelist):
         # magic
         if magic:
             filemeta_d.update(get_magic(buf))
+
+        # ssdeep
+        if ssdeep:
+            filemeta_d['ssdeep'] = ssdeep.hash_from_file(fname)
 
         results.append((fname, filemeta_d))
 

--- a/multiscanner/ms.py
+++ b/multiscanner/ms.py
@@ -859,7 +859,7 @@ def _init(args):
         try:
             answer = input('Do you wish to overwrite the configuration file [y/N]:')
         except EOFError as e:
-            logger.warn(e)
+            logger.warning(e)
             answer = 'N'
         if answer == 'y':
             config_init(args.config)
@@ -883,7 +883,7 @@ def _init(args):
         try:
             answer = input('Do you wish to overwrite the configuration file [y/N]:')
         except EOFError as e:
-            logger.warn(e)
+            logger.warning(e)
             answer = 'N'
         if answer == 'y':
             storage.config_init(config["storage-config"], overwrite=True)

--- a/multiscanner/storage/basic_elasticsearch_storage.py
+++ b/multiscanner/storage/basic_elasticsearch_storage.py
@@ -2,7 +2,6 @@
 Storage module that will interact with elasticsearch in a simple way.
 """
 import logging
-from uuid import uuid4
 
 from elasticsearch import Elasticsearch
 
@@ -42,7 +41,8 @@ class BasicElasticSearchStorage(storage.Storage):
             try:
                 report_id = report[filename]['filemeta']['sha256']
             except KeyError:
-                report_id = str(uuid4())
+                logger.warning("Unable to find sha256 hash for sample_id.")
+                raise
             report_id_list.append(report_id)
             report_data = self.dedot(report[filename])
             report_data = self.same_type_lists(report_data)

--- a/multiscanner/storage/basic_elasticsearch_storage.py
+++ b/multiscanner/storage/basic_elasticsearch_storage.py
@@ -42,7 +42,7 @@ class BasicElasticSearchStorage(storage.Storage):
             try:
                 report_id = report[filename]['filemeta']['sha256']
             except KeyError:
-                report_id = uuid4()
+                report_id = str(uuid4())
             report_id_list.append(report_id)
             report_data = self.dedot(report[filename])
             report_data = self.same_type_lists(report_data)

--- a/multiscanner/storage/elasticsearch_storage.py
+++ b/multiscanner/storage/elasticsearch_storage.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 from datetime import datetime
-from uuid import uuid4
 
 import curator
 
@@ -169,17 +168,17 @@ class ElasticSearchStorage(storage.Storage):
             sample = {
                 'doc_type': 'sample',
                 'filemeta': report[filename]['filemeta'],
-                'ssdeep': report[filename]['ssdeep'],
+                'ssdeep_analytics': report[filename]['ssdeep_analytics'],
                 'tags': [],
             }
 
             try:
-                del report[filename]['ssdeep']
+                del report[filename]['ssdeep_analytics']
+                del report[filename]['filemeta']
             except Exception as e:
                 pass
 
             report[filename]['doc_type'] = {'name': 'report', 'parent': sample_id}
-            report[filename]['filename'] = filename
             sample_tags[sample_id] = sample.get('tags', [])
 
             # If there is Cuckoo results in the report, some

--- a/multiscanner/storage/elasticsearch_storage.py
+++ b/multiscanner/storage/elasticsearch_storage.py
@@ -156,13 +156,13 @@ class ElasticSearchStorage(storage.Storage):
         sample_list = []
         sample_tags = {}  # track in case we need to update sample instead of create
 
-        logger.warn(report)
+        logger.warning(report)
         for filename in report:
             report[filename]['filename'] = filename
             try:
                 sample_id = report[filename]['filemeta']['sha256']
             except KeyError:
-                logger.warn("Unable to find sha256 hash for sample_id")
+                logger.warning("Unable to find sha256 hash for sample_id")
                 sample_id = uuid4()
             # Store metadata with the sample, not the report
             sample = {

--- a/multiscanner/storage/elasticsearch_storage.py
+++ b/multiscanner/storage/elasticsearch_storage.py
@@ -163,7 +163,7 @@ class ElasticSearchStorage(storage.Storage):
                 sample_id = report[filename]['filemeta']['sha256']
             except KeyError:
                 logger.warning("Unable to find sha256 hash for sample_id")
-                sample_id = uuid4()
+                sample_id = str(uuid4())
             # Store metadata with the sample, not the report
             sample = {
                 'doc_type': 'sample',

--- a/multiscanner/storage/mongo_storage.py
+++ b/multiscanner/storage/mongo_storage.py
@@ -14,11 +14,13 @@ functions:
         specified report.
 '''
 import json
-from uuid import uuid4
+import logging
 
 from pymongo import MongoClient
 
 from multiscanner.storage import storage
+
+logger = logging.getLogger(__name__)
 
 
 class MongoStorage(storage.Storage):
@@ -53,7 +55,8 @@ class MongoStorage(storage.Storage):
             try:
                 report_id = report[filename]['filemeta']['sha256']
             except KeyError:
-                report_id = str(uuid4())
+                logger.warning("Unable to find sha256 hash for sample_id.")
+                raise
             report_id_list.append(report_id)
 
             self.collection.update(

--- a/multiscanner/storage/mongo_storage.py
+++ b/multiscanner/storage/mongo_storage.py
@@ -53,7 +53,7 @@ class MongoStorage(storage.Storage):
             try:
                 report_id = report[filename]['filemeta']['sha256']
             except KeyError:
-                report_id = uuid4()
+                report_id = str(uuid4())
             report_id_list.append(report_id)
 
             self.collection.update(

--- a/multiscanner/storage/templates/elasticsearch_template.json
+++ b/multiscanner/storage/templates/elasticsearch_template.json
@@ -30,8 +30,15 @@
                     }
                 },
                 "filename": {"type": "text"},
-                "ssdeep": {
+                "filemeta": {
                     "properties": {
+                        "sha256": {"type": "keyword"},
+                        "ssdeep": {"type": "keyword"}
+                    }
+                },
+                "ssdeep_analytics": {
+                    "properties": {
+                        "analyzed": {"type": "boolean"},
                         "chunksize": {"type": "integer"},
                         "chunk": {
                             "analyzer": "ssdeep_analyzer",
@@ -40,11 +47,16 @@
                         "double_chunk": {
                             "analyzer": "ssdeep_analyzer",
                             "type": "text"
-                        },
-                        "ssdeep_hash": {"type": "keyword"}
+                        }
                     }
                 },
-                "timestamp": {"type": "date"}
+                "timestamp": {"type": "date"},
+                "Scan Metadata": {
+                    "properties": {
+                        "Scan Time": {"type": "date"},
+                        "Task ID": {"type": "integer"}
+                    }
+                }
             }
         }
     }

--- a/multiscanner/tests/test_api.py
+++ b/multiscanner/tests/test_api.py
@@ -191,7 +191,7 @@ class TestReportCase(APITestCase):
     @mock.patch('multiscanner.distributed.api.handler')
     def test_get_report(self, mock_handler):
         mock_handler.get_report.return_value = TEST_REPORT
-        expected_response = {'Report': TEST_REPORT}
+        expected_response = TEST_REPORT
         resp = self.app.get('/api/v1/tasks/1/report')
         self.assertEqual(resp.status_code, api.HTTP_OK)
         self.assertDictEqual(json.loads(resp.get_data().decode()), expected_response)

--- a/multiscanner/tests/test_elasticsearch.py
+++ b/multiscanner/tests/test_elasticsearch.py
@@ -39,7 +39,7 @@ class TestES(unittest.TestCase):
         sample_args = args[1][0]
         self.assertEqual(sample_args['pipeline'], 'dedot')
         self.assertEqual(sample_args['_id'], TEST_ID)
-        self.assertEqual(sample_args['_source']['sha256'], TEST_ID)
+        self.assertEqual(sample_args['_source']['filemeta']['sha256'], TEST_ID)
         self.assertEqual(sample_args['_source']['tags'], [])
 
         report_args, report_kwargs = mock_index.call_args_list[0]

--- a/multiscanner/tests/test_elasticsearch.py
+++ b/multiscanner/tests/test_elasticsearch.py
@@ -13,7 +13,7 @@ MS_WD = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 from multiscanner.storage.elasticsearch_storage import ElasticSearchStorage
 
-TEST_MS_OUTPUT = {'test.txt': {'filemeta': {'sha256': '03a634eb98ec54d5f7a3c964a82635359611d84dd4ba48e860e6d4817d4ca2a6', 'sha1': '02bed644797a7adb7d9e3fe8246cc3e1caed0dfe', 'md5': 'd74129f99f532292de5db9a90ec9d424', 'filetype': 'ASCII text, with very long lines, with no line terminators'}, 'ssdeep': '6:BLWw/ELmRCp8o7cu5eul3tkxZBBCGAAIwLE/mUz9kLTCDFM1K7NBVn4+MUq08:4w/ELmR48oJh1exX8G7TW+wM1uFwp', 'Metadata': {}, "Scan Time": "2017-09-26T16:48:05.395004"}}    # noqa: E501
+TEST_MS_OUTPUT = {'test.txt': {'filemeta': {'sha256': '03a634eb98ec54d5f7a3c964a82635359611d84dd4ba48e860e6d4817d4ca2a6', 'sha1': '02bed644797a7adb7d9e3fe8246cc3e1caed0dfe', 'md5': 'd74129f99f532292de5db9a90ec9d424', 'filetype': 'ASCII text, with very long lines, with no line terminators', 'ssdeep': '6:BLWw/ELmRCp8o7cu5eul3tkxZBBCGAAIwLE/mUz9kLTCDFM1K7NBVn4+MUq08:4w/ELmR48oJh1exX8G7TW+wM1uFwp'}, 'ssdeep_analytics': {}, 'Metadata': {}, "Scan Time": "2017-09-26T16:48:05.395004"}}    # noqa: E501
 TEST_ID = '03a634eb98ec54d5f7a3c964a82635359611d84dd4ba48e860e6d4817d4ca2a6'
 TEST_NOTE_ID = 'eba3d3de-1a7e-4018-8fb3-a4635b4b7ab1'
 TEST_TS = "2017-09-26T16:48:05.395004"


### PR DESCRIPTION
Other changes present in this merge:
- Removed support for UUID use when SHA256 is not present.
- filemeta construct is kept in sample, never broken at import/export
- Added `ssdeep` to filemeta. The other key/value are kept in `ssdeep_analytics`
- Updated code to reflect the filemeta/ssdeep changes
- Update elasticsearch_template to proper properties and their types

Closes #190