### PR TITLE
Follow some Docker best practices

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+.dockerignore
+docker-compose.yml
+docs/
+multiscanner/tests/
+.pre-commit-config.yaml
+tox.ini
+.travis.yml

--- a/docker_utils/Dockerfile
+++ b/docker_utils/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
-MAINTAINER Patrick Copeland ptcnop
+LABEL maintainer="Patrick Copeland ptcnop"
 
 ENV YARA_VERSION 3.8.1
 ENV YARA_PY_VERSION 3.8.1

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,9 @@ if [ -e /etc/debian_version ]; then
 fi
 
 # Install multiscanner library and dependencies
-curl -k https://bootstrap.pypa.io/get-pip.py | python
+if ! [ -x "$(command -v pip)" ]; then
+  curl -k https://bootstrap.pypa.io/get-pip.py | python
+fi
 pip install --upgrade $DIR
 
 #Code to compile and install yara


### PR DESCRIPTION
- Add a .dockerignore
- Use "LABEL maintainer" instead of "MAINTAINER"
- Only install pip if it doesn't already exist